### PR TITLE
Custom port support through env variable in context.xml

### DIFF
--- a/sdDAL/src/org/smap/sdal/Utilities/ServerConfig.java
+++ b/sdDAL/src/org/smap/sdal/Utilities/ServerConfig.java
@@ -1,0 +1,40 @@
+package org.smap.sdal.Utilities;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.http.HttpServletRequest;
+
+public class ServerConfig {
+
+    private static String host;
+    private static int portNumber;
+
+    static {
+        try {
+            Context env = (Context) new InitialContext().lookup("java:comp/env");
+
+            // Lookup for the environment variables defined in context.xml/server.xml
+            // host = (String) env.lookup("server.host");
+            portNumber = (Integer) env.lookup("server.port");
+
+        } catch (NamingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getHost(HttpServletRequest request) {
+        if (host != null && !host.isEmpty()) {
+            return host;
+        }
+        return request.getServerName();
+    }
+
+    public static int getPortNumber(HttpServletRequest request) {
+        if (portNumber != 0) {
+            return portNumber;
+        }
+        return request.getLocalPort();
+    }
+
+}

--- a/sdDAL/src/org/smap/sdal/managers/AssignmentsManager.java
+++ b/sdDAL/src/org/smap/sdal/managers/AssignmentsManager.java
@@ -23,6 +23,7 @@ import org.smap.sdal.Utilities.Authorise;
 import org.smap.sdal.Utilities.GeneralUtilityMethods;
 import org.smap.sdal.Utilities.ResultsDataSource;
 import org.smap.sdal.Utilities.SDDataSource;
+import org.smap.sdal.Utilities.ServerConfig;
 import org.smap.sdal.model.Case;
 import org.smap.sdal.model.CustomUserReference;
 import org.smap.sdal.model.FieldTaskSettings;
@@ -109,7 +110,7 @@ public class AssignmentsManager {
 		int uId = GeneralUtilityMethods.getUserId(sd, userIdent);
 
 		String host = request.getServerName();
-		String protocol = (request.getLocalPort() == 443) ? "https://" : "http://";
+		String protocol = (ServerConfig.getPortNumber(request) == 80) ? "http://" : "https://"; // request.getLocalPort();
 
 		// Get the coordinates from which this request was made
 		String latString = request.getHeader("lat");

--- a/setup/install/config_files/context.xml
+++ b/setup/install/config_files/context.xml
@@ -21,6 +21,9 @@
     <!-- Default set of monitored resources -->
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
 
+    <!-- <Environment name="server.host" value="example.com" type="java.lang.String"/> -->
+    <Environment name="server.port" value="61447" type="java.lang.Integer"/>
+
     <!-- Uncomment this to disable session persistence across Tomcat restarts -->
     <!--
     <Manager pathname="" />

--- a/surveyMobileAPI/src/surveyMobileAPI/managers/FormListManager.java
+++ b/surveyMobileAPI/src/surveyMobileAPI/managers/FormListManager.java
@@ -19,6 +19,7 @@ import org.smap.sdal.Utilities.AuthorisationException;
 import org.smap.sdal.Utilities.Authorise;
 import org.smap.sdal.Utilities.GeneralUtilityMethods;
 import org.smap.sdal.Utilities.SDDataSource;
+import org.smap.sdal.Utilities.ServerConfig;
 import org.smap.sdal.legacy.SurveyTemplate;
 import org.smap.sdal.managers.LogManager;
 import org.smap.sdal.managers.SurveyManager;
@@ -76,8 +77,9 @@ public class FormListManager {
 		}
 	    a.isAuthorised(sd, user);	//Authorisation - Access 
 
-		String host = request.getServerName();
-		int portNumber = request.getLocalPort();
+		String host = ServerConfig.getHost(request); // request.getServerName();
+		int portNumber = ServerConfig.getPortNumber(request); //request.getLocalPort();
+		log.log(Level.INFO, "Server Conf - portNumber", portNumber);
 		String javaRosaVersion = request.getHeader("X-OpenRosa-Version");
 		ArrayList<org.smap.sdal.model.Survey> surveys = null;
 		
@@ -219,10 +221,10 @@ public class FormListManager {
 			port = ":" + String.valueOf(portNumber);
 		}
 		
-		if(portNumber == 443) {
-			protocol = "https://";
-		} else {
+		if(portNumber == 80) {
 			protocol = "http://";
+		} else {
+			protocol = "https://";
 		}
 
 		// Extract the data

--- a/surveyMobileAPI/src/surveyMobileAPI/managers/ManifestManager.java
+++ b/surveyMobileAPI/src/surveyMobileAPI/managers/ManifestManager.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Context;
 import org.smap.sdal.Utilities.Authorise;
 import org.smap.sdal.Utilities.GeneralUtilityMethods;
 import org.smap.sdal.Utilities.SDDataSource;
+import org.smap.sdal.Utilities.ServerConfig;
 import org.smap.sdal.managers.ExternalFileManager;
 import org.smap.sdal.managers.SurveyManager;
 import org.smap.sdal.managers.TranslationManager;
@@ -62,7 +63,7 @@ public class ManifestManager {
 			String key) {
 		
 		String host = request.getServerName();
-		int portNumber = request.getLocalPort();
+		int portNumber = ServerConfig.getPortNumber(request);// request.getLocalPort();
 		String javaRosaVersion = request.getHeader("X-OpenRosa-Version");
 		String protocol = "";
 		StringBuilder responseStr = new StringBuilder();
@@ -98,10 +99,10 @@ public class ManifestManager {
 		a.isValidSurvey(sd, user, survey.surveyData.id, false, superUser);	// Validate that the user can access this survey
 		// End Authorisation
 		
-		if(portNumber == 443) {
-			protocol = "https://";
-		} else {
+		if(portNumber == 80) {
 			protocol = "http://";
+		} else {
+			protocol = "https://";
 		}
 
 		PreparedStatement pstmt = null;


### PR DESCRIPTION
This is for deployments where the application is configured in Apache to run on ports other than standard ports.

You can define the environment variable in context.xml file in tomcat configuration.